### PR TITLE
passfile flavor for re-alpine

### DIFF
--- a/mail/re-alpine/Makefile
+++ b/mail/re-alpine/Makefile
@@ -11,6 +11,8 @@ V=			2.02
 DISTNAME=		re-alpine-${V}
 EXTRACT_SUFX=		.tar.bz2
 
+REVISION=		1
+
 SHARED_LIBS=		c-client 5.1
 
 PICO_V=			5.05 # grep "PICO version" ${WRKSRC}/pico/pico.h

--- a/mail/re-alpine/pkg/DESCR-main
+++ b/mail/re-alpine/pkg/DESCR-main
@@ -11,5 +11,5 @@ This package is built using the re-alpine source, the continuation of
 the Alpine email client from University of Washington.
 
 The passfile flavor builds alpine with the option to store passwords
-in the file "~/.pine-passflie".  This should only be used in cases
+in the file "~/.pine-passfile".  This should only be used in cases
 where you are sure of the security of your local $HOME directory.


### PR DESCRIPTION
This patch adds a flavor for re-alpine (the current version of the old pine MUA) to turn on the fairly common option to save login info to a file ~/.pine-passfile.
