### PR TITLE
Switch pdftk to use gcc instead of clang so it compiles.

### DIFF
--- a/textproc/pdftk/Makefile
+++ b/textproc/pdftk/Makefile
@@ -46,7 +46,7 @@ CPPFLAGS+=	-fdollars-in-identifiers \
 CXXFLAGS+=	-L$(LOCALBASE)/lib
 LDLIBS+=	-lgcj -liconv -lz -pthread
 
-MAKE_ENV+=	CXX="$(CXX)" \
+MAKE_ENV+=	CXX=g++ \
 		GCJ="$(GCJ)" \
 		GCJH="$(GCJH)" \
 		GJAR="$(GJAR)" \


### PR DESCRIPTION
Doesn't look like pdftk builds with clang (since it uses gcj I'm guessing).  Seems to work fine this way.
