### PR TITLE
Rename Openbsd.pm to Bitrig.pm so p5-SDL will build properly.

### DIFF
--- a/devel/p5-SDL/Makefile
+++ b/devel/p5-SDL/Makefile
@@ -43,8 +43,8 @@ EXAMPLE_DIR =		${PREFIX}/share/examples/p5-SDL
 EXAMPLE_LOC =		${WRKSRC}/test
 
 pre-configure:
-	${SUBST_CMD} -c ${FILESDIR}/Openbsd.pm \
-		${WRKSRC}/make/lib/SDL/Build/Openbsd.pm
+	${SUBST_CMD} -c ${FILESDIR}/Bitrig.pm \
+		${WRKSRC}/make/lib/SDL/Build/Bitrig.pm
 
 post-install:
 	${INSTALL_DATA_DIR} -d ${EXAMPLE_DIR}/data

--- a/devel/p5-SDL/files/Bitrig.pm
+++ b/devel/p5-SDL/files/Bitrig.pm
@@ -1,4 +1,4 @@
-package SDL::Build::Openbsd;
+package SDL::Build::Bitrig;
 
 use base 'SDL::Build';
 # ${LOCALBASE}


### PR DESCRIPTION
Minor fix to get the perl SDL module to build.
