### PR TITLE
Update py-CherryPy to 3.2.4.

### DIFF
--- a/www/py-CherryPy/Makefile
+++ b/www/py-CherryPy/Makefile
@@ -2,7 +2,7 @@
 
 COMMENT=	pythonic, object-oriented web development framework
 
-MODPY_EGG_VERSION=	3.2.2
+MODPY_EGG_VERSION=	3.2.4
 DISTNAME=		CherryPy-${MODPY_EGG_VERSION}
 PKGNAME=		py-${DISTNAME}
 CATEGORIES=		www
@@ -12,12 +12,12 @@ HOMEPAGE=	http://www.cherrypy.org/
 # BSD
 PERMIT_PACKAGE_CDROM=	Yes
 
-MASTER_SITES=	http://download.cherrypy.org/cherrypy/${MODPY_EGG_VERSION}/
+MASTER_SITES=	${MASTER_SITE_PYPI:=C/CherryPy/}
 
 MODULES=	lang/python
 
 TEST_DEPENDS =	devel/py-nose \
-			www/py-routes
+		www/py-routes
 
 MODPY_SETUPTOOLS =	Yes
 

--- a/www/py-CherryPy/distinfo
+++ b/www/py-CherryPy/distinfo
@@ -1,2 +1,2 @@
-SHA256 (CherryPy-3.2.2.tar.gz) = 3FqIVieVwu5GLaxbN6uhz0808+JygewRBJInA5MItpE=
-SIZE (CherryPy-3.2.2.tar.gz) = 414099
+SHA256 (CherryPy-3.2.4.tar.gz) = q9c6RJk2dA6Z06BeuJuTgdwYjvaWkE9YVGO8KAefEog=
+SIZE (CherryPy-3.2.4.tar.gz) = 424074

--- a/www/py-CherryPy/pkg/PLIST
+++ b/www/py-CherryPy/pkg/PLIST
@@ -14,6 +14,8 @@ lib/python${MODPY_VERSION}/site-packages/cherrypy/_cpchecker.py
 lib/python${MODPY_VERSION}/site-packages/cherrypy/_cpchecker.pyc
 lib/python${MODPY_VERSION}/site-packages/cherrypy/_cpcompat.py
 lib/python${MODPY_VERSION}/site-packages/cherrypy/_cpcompat.pyc
+lib/python${MODPY_VERSION}/site-packages/cherrypy/_cpcompat_subprocess.py
+lib/python${MODPY_VERSION}/site-packages/cherrypy/_cpcompat_subprocess.pyc
 lib/python${MODPY_VERSION}/site-packages/cherrypy/_cpconfig.py
 lib/python${MODPY_VERSION}/site-packages/cherrypy/_cpconfig.pyc
 lib/python${MODPY_VERSION}/site-packages/cherrypy/_cpdispatch.py
@@ -139,6 +141,8 @@ lib/python${MODPY_VERSION}/site-packages/cherrypy/test/test_bus.py
 lib/python${MODPY_VERSION}/site-packages/cherrypy/test/test_bus.pyc
 lib/python${MODPY_VERSION}/site-packages/cherrypy/test/test_caching.py
 lib/python${MODPY_VERSION}/site-packages/cherrypy/test/test_caching.pyc
+lib/python${MODPY_VERSION}/site-packages/cherrypy/test/test_compat.py
+lib/python${MODPY_VERSION}/site-packages/cherrypy/test/test_compat.pyc
 lib/python${MODPY_VERSION}/site-packages/cherrypy/test/test_config.py
 lib/python${MODPY_VERSION}/site-packages/cherrypy/test/test_config.pyc
 lib/python${MODPY_VERSION}/site-packages/cherrypy/test/test_config_server.py


### PR DESCRIPTION
Also replaced downloads.cherrypy.org with MASTER_SITE_PYPI, because it
isn't up to date.
