### PR TITLE
Use http version of MASTER_SITES for py-genshi.

### DIFF
--- a/www/py-genshi/Makefile
+++ b/www/py-genshi/Makefile
@@ -16,7 +16,7 @@ PERMIT_PACKAGE_CDROM =	Yes
 
 WANTLIB += ${MODPY_WANTLIB} pthread
 
-MASTER_SITES =	ftp://ftp.edgewall.com/pub/genshi/
+MASTER_SITES =	http://ftp.edgewall.com/pub/genshi/
 
 MODULES =	lang/python
 

--- a/www/py-genshi/distinfo
+++ b/www/py-genshi/distinfo
@@ -1,5 +1,2 @@
-MD5 (Genshi-0.6.tar.gz) = YE6LI7RpdlXTamnC2O9xhw==
-RMD160 (Genshi-0.6.tar.gz) = vKBo2nlW8DNY0vRstGFuBlBriuk=
-SHA1 (Genshi-0.6.tar.gz) = i01dQ9xhS8g95Jxb4cO4o5CKgGI=
 SHA256 (Genshi-0.6.tar.gz) = Mqr3agP4jvoEFDv4BwA5nm2E7q2Bj90Z12P9dq+XKks=
 SIZE (Genshi-0.6.tar.gz) = 433946


### PR DESCRIPTION
The ftp site seems to be done (timeout).
